### PR TITLE
Adds new Kwik URL for AnimePahe

### DIFF
--- a/src/players/plyr/metadata.json
+++ b/src/players/plyr/metadata.json
@@ -11,6 +11,7 @@
     "*://aniwatch.me/*",
     "*://jzscuqezoqkcpvy.win/*",
     "*://kwik.cx/e/*",
+    "*://kwik.si/e/*",
     "*://plyr.link/*",
     "*://scloud.online/*",
     "*://stape.fun/*",


### PR DESCRIPTION
## Purpose

Adds new Kwik URL (kwik.si) to restore functionality in AnimePahe

And for some weird reason the `metadata.json` had Windows line endings so I converted the file to Unix line endings
